### PR TITLE
Refactor `get_user_info()` into two methods: `get_identity()` and `get_teams()`

### DIFF
--- a/validation_service_api/validation_service/auth.py
+++ b/validation_service_api/validation_service/auth.py
@@ -1,3 +1,4 @@
+import base64
 import requests
 import logging
 import json
@@ -7,7 +8,7 @@ import fairgraph.openminds.core as omcore
 
 from fastapi import HTTPException, status
 from authlib.integrations.starlette_client import OAuth
-from httpx import Timeout
+from httpx import AsyncClient, Timeout
 
 from . import settings
 
@@ -30,6 +31,18 @@ oauth.register(
         "timeout": Timeout(timeout=settings.AUTHENTICATION_TIMEOUT)
     },
 )
+
+
+def _decode_jwt_payload(token_str: str) -> dict:
+    try:
+        payload_b64 = token_str.split(".")[1]
+        payload_b64 += "=" * (4 - len(payload_b64) % 4)
+        return json.loads(base64.urlsafe_b64decode(payload_b64))
+    except Exception as err:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Could not decode token: {err}"
+        )
 
 
 def get_kg_client_for_service_account():
@@ -71,7 +84,8 @@ class User:
                 detail="You need to provide a bearer token to access this resource"
             )
         self.token = token
-        self._user_info = None
+        self._identity = None
+        self._teams = None
         self._collab_info = {}
         self._connection_error = False
 
@@ -79,33 +93,32 @@ class User:
     def is_anonymous(self):
         return self.token is None or self.token.credentials == "undefined"
 
-    async def get_user_info(self):
-        if self._user_info is None:
-            user_info = await oauth.ebrains.userinfo(
-                token={"access_token": self.token.credentials, "token_type": "bearer"}
-            )
-            if "error" in user_info:
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED, detail=user_info["error_description"]
-                )
-            elif user_info.get("statusCode", None) == 401:
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED, detail=user_info["message"]
-                )
-            elif user_info.get("statusCode", None) == 500:
-                raise HTTPException(
-                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail=f'Problem getting user_info: {user_info["message"]}'
-                )
-            logger.debug(user_info)
-            try:
-                # make this compatible with the v1 json
-                user_info["id"] = user_info["sub"]
-                user_info["username"] = user_info.get("preferred_username", "unknown")
-            except KeyError:
-                raise Exception(user_info)
-            self._user_info = user_info
-        return self._user_info
+    async def get_identity(self):
+        if self._identity is None:
+            payload = _decode_jwt_payload(self.token.credentials)
+            username = payload.get("preferred_username", "unknown")
+            self._identity = {
+                "sub": payload["sub"],
+                "id": payload["sub"],
+                "preferred_username": username,
+                "username": username,
+                "given_name": payload.get("given_name", ""),
+                "family_name": payload.get("family_name", ""),
+            }
+        return self._identity
+
+    async def get_teams(self):
+        if self._teams is None:
+            identity = await self.get_identity()
+            url = f"{settings.EBRAINS_IDM_API_URL}/teams"
+            headers = {"Authorization": f"Bearer {self.token.credentials}"}
+            params = {"username": identity["username"]}
+            async with AsyncClient() as client:
+                res = await client.get(url, headers=headers, params=params,
+                                       timeout=settings.AUTHENTICATION_TIMEOUT)
+            res.raise_for_status()
+            self._teams = [t["name"] for t in res.json() if isinstance(t, dict) and "name" in t]
+        return self._teams
 
     async def get_collab_info(self, collab_id):
         if collab_id not in self._collab_info:
@@ -122,9 +135,9 @@ class User:
         return self._collab_info[collab_id]
 
     async def get_person(self, kg_client):
-        user_info = await self.get_user_info()
-        family_name = user_info["family_name"]
-        given_name = user_info["given_name"]
+        identity = await self.get_identity()
+        family_name = identity["family_name"]
+        given_name = identity["given_name"]
         person = omcore.Person.list(kg_client, family_name=family_name, given_name=given_name, scope="any")
         if person:
             if isinstance(person, list):
@@ -139,14 +152,14 @@ class User:
             return None
 
     async def get_collab_permissions(self, collab_id):
-        user_info = await self.get_user_info()
+        teams = await self.get_teams()
 
         target_team_names = {role: f"collab-{collab_id}-{role}"
                             for role in ("viewer", "editor", "administrator")}
 
         highest_collab_role = None
         for role, team_name in target_team_names.items():
-            if team_name in user_info["roles"]["team"]:
+            if team_name in teams:
                 highest_collab_role = role
         if highest_collab_role == "viewer":
             permissions = {"VIEW": True, "UPDATE": False}
@@ -184,9 +197,9 @@ class User:
         # todo: replace this check with a group membership check
 
     async def get_editable_collabs(self):
-        user_info = await self.get_user_info()
+        teams = await self.get_teams()
         editable_collab_ids = set()
-        for team_name in user_info["roles"]["team"]:
+        for team_name in teams:
             if team_name.endswith("-editor") or team_name.endswith("-administrator"):
                 collab_id = "-".join(team_name.split("-")[1:-1])
                 editable_collab_ids.add(collab_id)

--- a/validation_service_api/validation_service/resources/auth.py
+++ b/validation_service_api/validation_service/resources/auth.py
@@ -59,7 +59,7 @@ async def list_projects(
         return []
     else:
         try:
-            user_info = await user.get_user_info()
+            teams = await user.get_teams()
         except HTTPStatusError as err:
             if "401" in str(err):
                 raise HTTPException(
@@ -68,9 +68,8 @@ async def list_projects(
                 )
             else:
                 raise
-        roles = user_info.get("roles", {}).get("team", [])
         projects = {}
-        for role in roles:
+        for role in teams:
             if role.startswith("collab-"):
                 project_id = "-".join(role.split("-")[1:-1])
                 if project_id not in projects:

--- a/validation_service_api/validation_service/resources/models.py
+++ b/validation_service_api/validation_service/resources/models.py
@@ -52,8 +52,8 @@ async def api_status(token: HTTPAuthorizationCredentials = Depends(auth)):
         }
     }
     if token:
-        user_info = await User(token).get_user_info()
-        info["user"] = user_info["preferred_username"]
+        identity = await User(token).get_identity()
+        info["user"] = identity["preferred_username"]
     service_status = getattr(settings, "SERVICE_STATUS", "ok")
     return info
 

--- a/validation_service_api/validation_service/resources/tests.py
+++ b/validation_service_api/validation_service/resources/tests.py
@@ -263,10 +263,10 @@ async def create_test(test: ValidationTest, token: HTTPAuthorizationCredentials 
     try:
         test_definition.save(kg_user_client, recursive=True, space=kg_space, ignore_duplicates=True)
     except AuthenticationError as err:
-        user_info = await user.get_user_info()
+        identity = await user.get_identity()
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"User {user_info['username']} cannot access space {kg_space}. Error message: {err}"
+            detail=f"User {identity['username']} cannot access space {kg_space}. Error message: {err}"
         )
     return ValidationTest.from_kg_object(test_definition, kg_user_client)
 

--- a/validation_service_api/validation_service/settings.py
+++ b/validation_service_api/validation_service/settings.py
@@ -17,6 +17,7 @@ BASE_URL = os.environ.get("VALIDATION_SERVICE_BASE_URL")
 SERVICE_STATUS = os.environ.get("VF_SERVICE_STATUS", "ok")
 # e.g. SERVICE_STATUS = "The site is undergoing maintenance, and is currently in read-only mode."
 AUTHENTICATION_TIMEOUT = 20
+EBRAINS_IDM_API_URL = os.environ.get("EBRAINS_IDM_API_URL", "https://idm.ebrains.eu")
 
 this_dir = os.path.dirname(__file__)
 build_info_path = os.path.join(this_dir, "build_info.json")

--- a/validation_service_api/validation_service/tests/test_user.py
+++ b/validation_service_api/validation_service/tests/test_user.py
@@ -25,10 +25,10 @@ async def test_user__is_admin():
 
 
 @pytest.mark.asyncio
-async def test_user_info():
+async def test_user_teams():
     user = User(token, allow_anonymous=False)
-    user_info = await user.get_user_info()
-    assert "collab-model-validation-administrator" not in user_info["roles"]["team"]
+    teams = await user.get_teams()
+    assert "collab-model-validation-administrator" not in teams
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- `get_identity()` doesn't need a network call, because we can decode user information from the JWT token
- `get_teams()` uses the IDM API instead of IAM userinfo